### PR TITLE
Remove explicit highlighter type check

### DIFF
--- a/src/search/Highlight.js
+++ b/src/search/Highlight.js
@@ -357,11 +357,7 @@
           return highlight.type;
         }
 
-        t = t.toLowerCase();
-        if (t === 'fvh' || t === 'plain' ||
-            t === 'postings') {
-          addOption(oField, 'type', t);
-        }
+        addOption(oField, 'type', t);
 
         return this;
       },


### PR DESCRIPTION
Elastic supports custom highlighters.

We use one internally and this silently fails to add the type to the highlight request.
