### PR TITLE
docs: Add link to alternate lib elastic-builder in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-It's a maintained fork
+elastic.js can be used with elasticsearch 2.x and lower.
+There were several [breaking changes](https://www.elastic.co/guide/en/elasticsearch/reference/5.x/breaking_50_search_changes.html) in the 5.x release for the Query DSL.
+
+You can try [elastic-builder](https://github.com/sudo-suhas/elastic-builder) for elasticsearch version >= 5.x.
 
 doc is here : https://cdn.rawgit.com/ErwanPigneul/elastic.js/master/dist/docs/ejs.html
 
@@ -8,7 +11,7 @@ doc is here : https://cdn.rawgit.com/ErwanPigneul/elastic.js/master/dist/docs/ej
 
 # elastic.js
 
-A JavaScript implementation of the [ElasticSearch](http://www.elasticsearch.org/) DSL for use with the [official elasticsearch javascript client](http://www.elasticsearch.org/guide/en/elasticsearch/client/javascript-api/current/index.html).  
+A JavaScript implementation of the [ElasticSearch](http://www.elasticsearch.org/) DSL for use with the [official elasticsearch javascript client](http://www.elasticsearch.org/guide/en/elasticsearch/client/javascript-api/current/index.html).
 
 ## Documentation
 You can find the official documentation at the following locations:
@@ -74,9 +77,9 @@ _Also, please don't edit elastic.js and elastic.min.js files as they are generat
 
 ## Some tips (memo)
 cd docs/
-./build.sh 
+./build.sh
 
-## 
+##
 
 ## License
 Copyright (c) 2012-2014 FullScale Labs, LLC


### PR DESCRIPTION
Adds link to [elastic-builder](/sudo-suhas/elastic-builder) in README. I have also mentioned elasticsearch compatibility and linked the DSL changes in 5.x.

#### Links
Demo - https://elastic-builder.js.org/
Docs - https://elastic-builder.js.org/docs

Let me know if you want me to change anything.